### PR TITLE
Feature/discord chat log toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@
 - ✅ In-game configuration via commands 🎮
 - ✅ Update notifications for new mod versions 🔔
 - ✅ Paginated player list and server status via Discord slash commands 📊
-
 ---
 
 ## 🚀 Installation
@@ -72,35 +71,37 @@ All configuration is done in-game using `/blocketing` commands (OP only):
 
 ### Setup Discord Integration
 
-- `/blocketing setup token <token>`  
+- `/blocketing setup token <token>`
   Set the Discord bot token.
-- `/blocketing setup guild <guild_id>`  
+- `/blocketing setup guild <guild_id>`
   Set the Discord server (guild) ID.
-- `/blocketing setup channel <channel_id>`  
+- `/blocketing setup channel <channel_id>`
   Set the Discord channel ID for message sync.
-- `/blocketing setup op_role <role_id>`  
+- `/blocketing setup op_role <role_id>`
   Set the Discord role ID required to run `/console` from Discord.
-- `/blocketing setup webhook_url <url>`  
+- `/blocketing setup webhook_url <url>`
   Set the Discord webhook URL for player chat webhook mode.
-- `/blocketing setup`  
+- `/blocketing setup`
   List available setup commands.
 
 ### Feature Toggles
 
-- `/blocketing toggle advancements`  
+- `/blocketing toggle advancements`
   Enable/disable sending advancement messages to Discord.
-- `/blocketing toggle deaths`  
+- `/blocketing toggle deaths`
   Enable/disable sending death messages to Discord.
-- `/blocketing toggle player_chat_mode`  
+- `/blocketing toggle player_chat_mode`
   Enable/disable player chat webhook mode (uses webhook for chat, with player avatar and name).
-- `/blocketing toggle update-info`  
+- `/blocketing toggle update-info`
   Enable/disable update notifications for new mod versions.
-- `/blocketing toggle`  
+- `/blocketing toggle discord_chat_log`
+  Enable/disable logging of Discord chat messages to the server console.
+- `/blocketing toggle`
   List available toggles.
 
 ### Other Commands
 
-- `/blocketing reload`  
+- `/blocketing reload`
   Reload the configuration and restart the Discord bot.
 
 ---

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,9 @@ yarn_mappings=1.21.9+build.1
 loader_version=0.17.2
 
 # Mod Properties
-mod_version=2.4.4
+mod_version=2.5.0
 maven_group=com.blocketing
 archives_base_name=blocketing
 
 # Dependencies
-fabric_version=0.133.14+1.21.9
+fabric_version=0.134.0+1.21.9

--- a/src/main/java/com/blocketing/commands/ConfigurationCommand.java
+++ b/src/main/java/com/blocketing/commands/ConfigurationCommand.java
@@ -145,9 +145,18 @@ public final class ConfigurationCommand {
                                     return 1;
                                 })
                         )
+                        // Toggle Discord chat logging
+                        .then(CommandManager.literal("discord_chat_log")
+                                .executes(context -> {
+                                    boolean enabled = !ConfigLoader.getBooleanProperty("DISCORD_CHAT_LOG_ENABLED", false);
+                                    ConfigLoader.setProperty("DISCORD_CHAT_LOG_ENABLED", String.valueOf(enabled));
+                                    context.getSource().sendFeedback(() -> Text.of("Discord-Chat-Logging is now " + (enabled ? "enabled" : "disabled") + "."), true);
+                                    return 1;
+                                })
+                        )
                         // List available toggles
                         .executes(context -> {
-                            context.getSource().sendFeedback(() -> Text.of("Available toggles: advancements, deaths, player_chat_mode, update-info"), true);
+                            context.getSource().sendFeedback(() -> Text.of("Available toggles: advancements, deaths, player_chat_mode, update-info, discord_chat_log"), true);
                             return 1;
                         })
                 )

--- a/src/main/java/com/blocketing/config/ConfigLoader.java
+++ b/src/main/java/com/blocketing/config/ConfigLoader.java
@@ -45,6 +45,11 @@ public final class ConfigLoader {
             try (InputStream input = Files.newInputStream(Paths.get(CONFIG_PATH))) {
                 config.load(input);
             }
+            // Set default values for missing properties
+            if (!config.containsKey("DISCORD_CHAT_LOG_ENABLED")) {
+                config.setProperty("DISCORD_CHAT_LOG_ENABLED", "true");
+                saveConfig();
+            }
         } catch (IOException e) {
             LOGGER.error("Error loading the configuration file", e);
         }

--- a/src/main/java/com/blocketing/discord/listener/JdaMessageListener.java
+++ b/src/main/java/com/blocketing/discord/listener/JdaMessageListener.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import com.blocketing.config.ConfigLoader;
 import com.blocketing.Blocketing;
 import net.minecraft.server.MinecraftServer;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class listens for messages received in a specific Discord channel
@@ -23,6 +24,11 @@ public class JdaMessageListener extends ListenerAdapter {
         String channelId = ConfigLoader.getProperty("CHANNEL_ID");
         if (!event.getChannel().getId().equals(channelId)) return; // Check if the message is in the configured channel
         if (!event.getMessage().getAttachments().isEmpty() || !event.getMessage().getEmbeds().isEmpty()) return; // Ignore messages with attachments or embeds
+
+        // Log Discord-Message to console if enabled
+        if (ConfigLoader.getBooleanProperty("DISCORD_CHAT_LOG_ENABLED", false)) {
+            LoggerFactory.getLogger("Blocketing|Discord|Chat").info("[Discord] <{}>: {}", event.getAuthor().getName(), event.getMessage().getContentDisplay());
+        }
 
         // Get the Minecraft server instance
         MinecraftServer server = Blocketing.getMinecraftServer();


### PR DESCRIPTION
This pull request introduces a new feature for logging Discord chat messages to the server console and updates related documentation and configuration. It also includes a version bump for the mod and its dependencies. The most important changes are grouped below:

### Feature: Discord Chat Logging

* Added a new `/blocketing toggle discord_chat_log` command to enable or disable logging of Discord chat messages to the server console, with feedback to the user. The toggle is now listed in the available toggles output. (`ConfigurationCommand.java`)
* Implemented console logging for Discord chat messages in `JdaMessageListener.java`, gated by the new configuration property. (`JdaMessageListener.java`)
* Set a default value for `DISCORD_CHAT_LOG_ENABLED` in the configuration loader to ensure the feature is enabled by default for new installations. (`ConfigLoader.java`)

### Documentation Updates

* Updated the README to include the new Discord chat log toggle command and reflect changes in available toggles. 

### Version Updates

* Bumped the mod version to `2.5.0` and updated the Fabric loader dependency version in `gradle.properties`. (`gradle.properties`)